### PR TITLE
2.0.1 adjustments patch

### DIFF
--- a/Utilities/CombatObject.py
+++ b/Utilities/CombatObject.py
@@ -371,6 +371,8 @@ class CombatInstance:
         # Base damage boost from critical strikes
         bonus_occ = agent.type == "Engineer"
         crit_bonus = .75 if bonus_occ else .5
+        if agent.assc.type == "College":
+            crit_bonus += .05 * agent.assc.get_level()
         agent.crit_hit = True
 
         # Applicable acolytes: Aulus, Ayesha

--- a/Utilities/CombatObject.py
+++ b/Utilities/CombatObject.py
@@ -140,22 +140,22 @@ class Belligerent:
             attack = difficulty * 7
             crit = int(difficulty * 1.2) + 5
             hp = difficulty * 67
-            defense = int(difficulty * 1.3)
+            defense = int(difficulty * 1.2)
         elif difficulty < 25:
             attack = difficulty * 10
             crit = int(difficulty * 1.5) + 5
             hp = difficulty * 75
-            defense = int(difficulty * 1.4)
+            defense = int(difficulty * 1.3)
         elif difficulty < 40:
             attack = difficulty * 20
             crit = 65
             hp = difficulty * 125
-            defense = 60
+            defense = 40
         elif difficulty < 50:
             attack = difficulty * 25
             crit = 75
             hp = difficulty * 140
-            defense = 67
+            defense = 55
         else:
             attack = difficulty * 28
             crit = 78

--- a/Utilities/ItemObject.py
+++ b/Utilities/ItemObject.py
@@ -163,6 +163,16 @@ class Armor:
             self.name = "No Armor"
             self.defense = 0
 
+    async def set_owner(self, conn : asyncpg.Connection, user_id : int):
+        """Changes the owner of this armor."""
+        if self.is_empty:
+            raise Checks.EmptyObject
+
+        self.owner_id = user_id
+
+        psql = "UPDATE armor SET user_id = $1 WHERE armor_id = $2;"
+        await conn.execute(psql, user_id, self.id)
+
     async def destroy(self, conn : asyncpg.Connection):
         """Deletes this item from the database."""
         if self.is_empty:

--- a/Utilities/PlayerObject.py
+++ b/Utilities/PlayerObject.py
@@ -684,7 +684,7 @@ class Player:
         attack += Vars.ORIGINS[self.origin]['atk_bonus']
         if self.assc.type == "Brotherhood":
             lvl = self.assc.get_level()
-            attack += int(lvl * (lvl + 1) / 4)
+            attack += lvl * 3
         attack += Vars.OCCUPATIONS[self.occupation]['atk_bonus']
         attack = int(attack * 1.1) if self.occupation == "Soldier" else attack
         if self.accessory.prefix == "Demonic":
@@ -702,8 +702,6 @@ class Player:
         crit += self.acolyte1.get_crit()
         crit += self.acolyte2.get_crit()
         crit += Vars.ORIGINS[self.origin]['crit_bonus']
-        if self.assc.type == "Brotherhood":
-            crit += self.assc.get_level()
         crit += Vars.OCCUPATIONS[self.occupation]['crit_bonus']
         if self.accessory.prefix == "Flexible":
             crit += Vars.ACCESSORY_BONUS["Flexible"][self.accessory.type]
@@ -738,6 +736,8 @@ class Player:
                 base += 3
             if not self.boots.is_empty:
                 base += 3
+        if self.assc.type == "Guild":
+            base += self.assc.get_level()
         if self.accessory.prefix == "Strong":
             base += Vars.ACCESSORY_BONUS["Strong"][self.accessory.type]
         acolytes = (self.acolyte1.acolyte_name, self.acolyte2.acolyte_name)

--- a/Utilities/Vars.py
+++ b/Utilities/Vars.py
@@ -1,5 +1,5 @@
-ACOLYTE_LIST_PATH = r'F:\OneDrive\Python_Projects\Ayesha_Rewrite\Assets\Acolyte_List.json'
-# ACOLYTE_LIST_PATH = r'C:\Users\sebas\OneDrive\Python_Projects\Ayesha_Rewrite\Assets\Acolyte_List.json'
+# ACOLYTE_LIST_PATH = r'F:\OneDrive\Python_Projects\Ayesha_Rewrite\Assets\Acolyte_List.json'
+ACOLYTE_LIST_PATH = r'C:\Users\sebas\OneDrive\Python_Projects\Ayesha_Rewrite\Assets\Acolyte_List.json'
 
 ABLUE = 0xBEDCF6
 
@@ -37,17 +37,17 @@ ACCESSORY_BONUS = {
     'Strong' : { # additional DEF
         'Wood' : 3,
         'Glass' : 3,
-        'Copper' : 5,
-        'Jade' : 5,
-        'Pearl' : 6,
-        'Aquamarine' : 7,
-        'Sapphire' : 8,
-        'Amethyst' : 9,
-        'Ruby' : 9,
-        'Garnet' : 11,
-        'Diamond' : 12,
-        'Emerald' : 14,
-        'Black Opal' : 15
+        'Copper' : 4,
+        'Jade' : 4,
+        'Pearl' : 5,
+        'Aquamarine' : 5,
+        'Sapphire' : 6,
+        'Amethyst' : 6,
+        'Ruby' : 6,
+        'Garnet' : 7,
+        'Diamond' : 8,
+        'Emerald' : 9,
+        'Black Opal' : 10
     },
     'Shiny' : { # reduces critdmg by x%
         'Wood' : 5,
@@ -154,33 +154,33 @@ ARMOR_DEFENSE = {
         'Cloth' : 1,
         'Wood' : 2,
         'Silk' : 3,
-        'Leather' : 5,
-        'Gambeson' : 6,
-        'Wolfskin' : 7,
-        'Bearskin' : 8,
-        'Bronze' : 7,
-        'Ceramic Plate' : 10,
-        'Chainmail' : 11,
-        'Iron' : 12,
-        'Steel' : 15,
-        'Mysterious' : 16,
-        'Dragonscale' : 17
+        'Leather' : 3,
+        'Gambeson' : 3,
+        'Wolfskin' : 4,
+        'Bearskin' : 4,
+        'Bronze' : 5,
+        'Ceramic Plate' : 6,
+        'Chainmail' : 6,
+        'Iron' : 7,
+        'Steel' : 9,
+        'Mysterious' : 11,
+        'Dragonscale' : 12
     },
     'Bodypiece' : {
         'Cloth' : 3,
         'Wood' : 5,
-        'Silk' : 7,
-        'Leather' : 8,
-        'Gambeson' : 10,
-        'Wolfskin' : 12,
-        'Bearskin' : 13,
-        'Bronze' : 12,
-        'Ceramic Plate' : 14,
-        'Chainmail' : 15,
-        'Iron' : 16,
-        'Steel' : 18,
-        'Mysterious' : 20,
-        'Dragonscale' : 22
+        'Silk' : 6,
+        'Leather' : 7,
+        'Gambeson' : 7,
+        'Wolfskin' : 8,
+        'Bearskin' : 9,
+        'Bronze' : 9,
+        'Ceramic Plate' : 10,
+        'Chainmail' : 10,
+        'Iron' : 11,
+        'Steel' : 13,
+        'Mysterious' : 15,
+        'Dragonscale' : 16
     },
     'Boots' : {
         'Cloth' : 1,
@@ -193,10 +193,10 @@ ARMOR_DEFENSE = {
         'Bronze' : 7,
         'Ceramic Plate' : 1,
         'Chainmail' : 8,
-        'Iron' : 10,
-        'Steel' : 12,
-        'Mysterious' : 15,
-        'Dragonscale' : 18
+        'Iron' : 9,
+        'Steel' : 10,
+        'Mysterious' : 12,
+        'Dragonscale' : 13
     },
 }
 

--- a/cogs/Acolytes.py
+++ b/cogs/Acolytes.py
@@ -81,30 +81,32 @@ class Acolytes(commands.Cog):
     
     # COMMANDS
     @commands.slash_command()
-    async def acolyte_list(self, ctx):
-        """View a list of all acolytes attainable in-game."""
-        with open(Vars.ACOLYTE_LIST_PATH, "r") as f:
-            aco_dict = json.load(f)
-            aco_list = [[] for _ in range(5)]
-            for acolyte in aco_dict: # Each list in list contains same rank aco
-                aco_list[aco_dict[acolyte]["Rarity"]-1].append(acolyte)
-
-        embeds = []
-        for i in range(len(aco_list)-1, -1, -1): # Show higher ranks first
-            embed = discord.Embed(
-                title="Attainable Acolytes",
-                description=f"({i+1}⭐) " + f"\n({i+1}⭐) ".join(aco_list[i]),
-                color=Vars.ABLUE)
-            embeds.append(embed)
-        
-        paginator = pages.Paginator(pages=embeds, timeout=30)
-        await paginator.respond(ctx.interaction)
-
-    @commands.slash_command()
     async def acolyte(self, ctx,
         name : Option(str, 
-            description="The name of the acolyte you are viewing")):
+            description="The name of the acolyte you are viewing",
+            required=False)):
         """View an acolyte's general information."""
+        # Give a list of all acolytes if no name is given
+        if name is None:
+            with open(Vars.ACOLYTE_LIST_PATH, "r") as f:
+                aco_dict = json.load(f)
+                aco_list = [[] for _ in range(5)]
+                for acolyte in aco_dict: # Each list in list contains same rank
+                    aco_list[aco_dict[acolyte]["Rarity"]-1].append(acolyte)
+
+            embeds = []
+            for i in range(len(aco_list)-1, -1, -1): # Show higher ranks first
+                embed = discord.Embed(
+                    title="Attainable Acolytes",
+                    description=
+                        f"({i+1}⭐) " + f"\n({i+1}⭐) ".join(aco_list[i]),
+                    color=Vars.ABLUE)
+                embeds.append(embed)
+        
+            paginator = pages.Paginator(pages=embeds, timeout=30)
+            return await paginator.respond(ctx.interaction)
+
+        # Otherwise get acolyte asked for
         if name.lower() == "prxrdr":
             name = "PrxRdr"
         else:

--- a/cogs/Associations.py
+++ b/cogs/Associations.py
@@ -700,13 +700,13 @@ class Associations(commands.Cog):
                     k=2)
                 att_team[i].last_move = moves[0]
                 def_team[i].last_move = moves[1]
-                # SImulate the battle
+                # Simulate the battle
                 combat = CombatInstance(att_team[i], def_team[i], turn_counter)
                 battle_log.append(combat.get_turn_str())
                 att_team[i], def_team[i] = combat.apply_damage()
 
                 # Break loop under these victory conditions
-                if turn_counter > 5 or att_team[i].current_hp <= 0:
+                if turn_counter > 15 or att_team[i].current_hp <= 0:
                     defender_wins += 1
                     break
                 elif def_team[i].current_hp <= 0:


### PR DESCRIPTION
Merges `/acolyte` and `/acolyte_list` commands (resolves #26 )
Increase `/brotherhood attack` combat turn limit from 5 to 15
Changes stat bonuses for association members (resolves #24 )
Allows players to offer armor but no longer give away gold (resolves #23 )
Implements guild account interest rates (resolves #21 )