### PR TITLE
2.0.2 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ayesha is currently being rewritten using pycord after the discontinuation of di
 
 ## Requirements
 - Python 3.8.12
-- [pycord](https://pypi.org/project/py-cord/) v.2.0.0a4
+- [pycord](https://pypi.org/project/py-cord/) v.2.0.0b1
 - [asyncpg](https://pypi.org/project/asyncpg/) v.0.25.0
 - [aiohttp](https://pypi.org/project/aiohttp/3.7.4.post0/) v.3.7.4.post0
 - [coolname](https://pypi.org/project/coolname/) v.1.1.0

--- a/Utilities/CombatObject.py
+++ b/Utilities/CombatObject.py
@@ -347,9 +347,9 @@ class CombatInstance:
         for p in (self.player1, self.player2):
             if p.last_move in ("Attack", "Block", "Parry"):
                 temp = {
-                    "Attack" : "attacked",
-                    "Block" : "blocked",
-                    "Parry" : "parried"
+                    "Attack" : "🗡️",
+                    "Block" : "\N{SHIELD}",
+                    "Parry" : "\N{CROSSED SWORDS}"
                 }
                 if p.crit_hit:
                     output += (
@@ -360,10 +360,10 @@ class CombatInstance:
                         f"**{p.name}** {temp[p.last_move]} for **{p.damage}** "
                         f"damage. ")
             elif p.last_move == "Heal":
-                output += f"**{p.name}** healed for **{p.heal}** HP. "
+                output += f"**{p.name}** \u2764 for **{p.heal}** HP. "
             else:
                 output += (
-                    f"**{p.name}** bided their time. ")
+                    f"**{p.name}** decided to \u23F1. ")
         return output
 
     # Independent event as it happens during damage calculation

--- a/Utilities/PlayerObject.py
+++ b/Utilities/PlayerObject.py
@@ -172,7 +172,7 @@ class Player:
         self.level = self.get_level()
 
     async def check_xp_increase(self, conn : asyncpg.Connection, 
-            ctx : discord.context, xp : int):
+            ctx, xp : int):
         """Increase the player's xp by a set amount.
         This will also increase the player's equipped acolytes xp by 10% of the 
         player's increase.
@@ -191,21 +191,22 @@ class Player:
         self.level = self.get_level()
         # if self.level > old_level: # Level up
         gold, rubidics = 0, 0
-        for new_level in range(old_level+1, self.level+1): # Handle mult lvl-ups
-            gold += new_level * 500
-            rubidics += int(new_level / 30) + 1
+        if self.level > old_level:
+            for new_level in range(old_level+1, self.level+1):
+                gold += new_level * 500 # Handle multiple lvl-ups
+                rubidics += int(new_level / 30) + 1
 
-        await self.give_gold(conn, gold)
-        await self.give_rubidics(conn, rubidics)
+            await self.give_gold(conn, gold)
+            await self.give_rubidics(conn, rubidics)
 
-        embed = discord.Embed(
-            title = f"You have levelled up to level {self.level}!",
-            color = Vars.ABLUE)
-        embed.add_field(
-            name = f"{self.char_name}, you gained some rewards",
-            value = f"**Gold:** {gold}\n**Rubidics:** {rubidics}")
+            embed = discord.Embed(
+                title = f"You have levelled up to level {self.level}!",
+                color = Vars.ABLUE)
+            embed.add_field(
+                name = f"{self.char_name}, you gained some rewards",
+                value = f"**Gold:** {gold}\n**Rubidics:** {rubidics}")
 
-        await ctx.respond(embed=embed)
+            await ctx.respond(embed=embed)
 
         # Check xp for the equipped acolytes
         a_xp = int(xp / 10)
@@ -541,7 +542,7 @@ class Player:
                     amount*-1 - self.resources[resource], 
                     self.resources[resource])
         except KeyError:
-            raise Checks.InvalidResource
+            raise Checks.InvalidResource(resource)
 
         psql = f"""
                 UPDATE resources

--- a/Utilities/Vars.py
+++ b/Utilities/Vars.py
@@ -486,6 +486,7 @@ TRAVEL_LOCATIONS = {
     'Aramithea' : {
         'Biome' : 'City', 
         'Drops' : 'You can `upgrade` your weapons here.',
+        'Forage' : None,
         'Destinations' : {
             'Aramithea' : 0,
             'Mythic Forest' : 1800,
@@ -504,6 +505,7 @@ TRAVEL_LOCATIONS = {
     'Mythic Forest' : {
         'Biome' : 'Forest',
         'Drops' : 'You can `hunt` and `forage` here for `fur`, `bone`, and `wood`.',
+        'Forage' : 'Wood',
         'Destinations' : {
             'Aramithea' : 1800,
             'Mythic Forest' : 0,
@@ -522,6 +524,7 @@ TRAVEL_LOCATIONS = {
     'Thenuille' : {
         'Biome' : 'Town', 
         'Drops' : 'You can `upgrade` your weapons here and `fish`.',
+        'Forage' : None,
         'Destinations' : {
             'Aramithea' : 1800,
             'Mythic Forest' : 1800,
@@ -540,6 +543,7 @@ TRAVEL_LOCATIONS = {
     'Fernheim' : {
         'Biome' : 'Grassland', 
         'Drops' : 'You can `hunt` and `forage` here for `fur`, `bone`, and `wheat`.',
+        'Forage' : 'Wheat',
         'Destinations' : {
             'Aramithea' : 1800,
             'Mythic Forest' : 3600,
@@ -558,6 +562,7 @@ TRAVEL_LOCATIONS = {
     'Sunset Prairie' : {
         'Biome' : 'Grassland', 
         'Drops' : 'You can `hunt` and `forage` here for `fur`, `bone`, and `oats`.',
+        'Forage' : 'Oat',
         'Destinations' : {
             'Aramithea' : 0,
             'Mythic Forest' : 0,
@@ -576,6 +581,7 @@ TRAVEL_LOCATIONS = {
     'Riverburn' : {
         'Biome' : 'City', 
         'Drops' : 'You can `upgrade` your weapons here.',
+        'Forage' : None,
         'Destinations' : {
             'Aramithea' : 1800,
             'Mythic Forest' : 3600,
@@ -594,6 +600,7 @@ TRAVEL_LOCATIONS = {
     'Thanderlans' : {
         'Biome' : 'Marsh', 
         'Drops' : 'You can `forage` here for `reeds`.',
+        'Forage' : 'Reeds',
         'Destinations' : {
             'Aramithea' : 3600,
             'Mythic Forest' : 7200,
@@ -612,6 +619,7 @@ TRAVEL_LOCATIONS = {
     'Glakelys' : {
         'Biome' : 'Grassland', 
         'Drops' : 'You can `hunt` and `forage` here for `fur`, `bone`, and `oats`.',
+        'Forage' : 'Oat',
         'Destinations' : {
             'Aramithea' : 3600,
             'Mythic Forest' : 7200,
@@ -630,6 +638,7 @@ TRAVEL_LOCATIONS = {
     'Russe' : {
         'Biome' : 'Taiga', 
         'Drops' : 'You can `hunt` and `forage` here for `fur`, `bone`, `pine`, and `moss`.',
+        'Forage' : 'Pine, Moss',
         'Destinations' : {
             'Aramithea' : 7200,
             'Mythic Forest' : 10800,
@@ -648,6 +657,7 @@ TRAVEL_LOCATIONS = {
     'Croire' : {
         'Biome' : 'Grassland', 
         'Drops' : 'You can `hunt` and `forage` here for `fur`, and `wheat`.',
+        'Forage' : 'Wheat',
         'Destinations' : {
             'Aramithea' : 7200,
             'Mythic Forest' : 10800,
@@ -666,6 +676,7 @@ TRAVEL_LOCATIONS = {
     'Crumidia' : {
         'Biome' : 'Hills', 
         'Drops' : 'You can `mine` and `forage` here for `iron` and `silver`.',
+        'Forage' : 'Iron, Silver',
         'Destinations' : {
             'Aramithea' : 5400,
             'Mythic Forest' : 7200,
@@ -684,6 +695,7 @@ TRAVEL_LOCATIONS = {
     'Kucre' : {
         'Biome' : 'Jungle', 
         'Drops' : 'You can `forage` here for `cacao`.',
+        'Forage' : 'Cacao',
         'Destinations' : {
             'Aramithea' : 14400,
             'Mythic Forest' : 10800,

--- a/cogs/Gacha.py
+++ b/cogs/Gacha.py
@@ -231,7 +231,7 @@ class Gacha(commands.Cog):
             want : Option(str,
                 description=f"The material you want to receive",
                 choices=ex_mats)):
-        """Exchange 20 of your excess resources for 2 of another or 1 gold."""
+        """Exchange 10 of your excess resources for 1 gold or another resource."""
         # Check for valid input
         if offer == want:
             return await ctx.respond(f"This is an unfavorable trade.")

--- a/cogs/Occupations.py
+++ b/cogs/Occupations.py
@@ -67,7 +67,7 @@ class Occupations(commands.Cog):
     # COMMANDS
     @commands.slash_command()
     @commands.check(Checks.is_player)
-    @cooldown(3, 259200, BucketType.user)
+    @cooldown(1, 86400, BucketType.user)
     async def lore(self, ctx, 
             setting : Option(str,
                 description="The aspect of your profile to change",
@@ -91,14 +91,18 @@ class Occupations(commands.Cog):
                     occ = menu.values[0]
                 except IndexError: # pressed confirm on home page
                     await ctx.respond("Don't confirm the landing page.")
+                    ctx.command.reset_cooldown(ctx)
                 else:
                     async with self.bot.db.acquire() as conn:
                         player = await PlayerObject.get_player_by_id(
                             conn, ctx.author.id)
                         await player.set_occupation(conn, occ)
                         await ctx.respond(f"You are now a **{occ}**!")
+                        if player.level <= 10:
+                            ctx.command.reset_cooldown(ctx)
             else:
                 await ctx.respond("You decided not to change your occupation.")
+                ctx.command.reset_cooldown(ctx)
             await msg.delete_original_message()
 
         else:
@@ -116,14 +120,18 @@ class Occupations(commands.Cog):
                     ori = menu.values[0]
                 except IndexError: # pressed confirm on home page
                     await ctx.respond("Don't confirm the landing page.")
+                    ctx.command.reset_cooldown(ctx)
                 else:
                     async with self.bot.db.acquire() as conn:
                         player = await PlayerObject.get_player_by_id(
                             conn, ctx.author.id)
                         await player.set_origin(conn, ori)
                         await ctx.respond(f"Homeland set to **{ori}**!")
+                        if player.level <= 10:
+                            ctx.command.reset_cooldown(ctx)
             else:
                 await ctx.respond("You decided not to change your origin.")
+                ctx.command.reset_cooldown(ctx)
             await msg.delete_original_message()
 
 

--- a/cogs/PvE.py
+++ b/cogs/PvE.py
@@ -105,7 +105,12 @@ class PvE(commands.Cog):
         interaction = await ctx.respond("Loading battle...")
         turn_counter = 1
         boss_next_move = random.choices(
-            population=["Attack", "Block", "Parry", "Heal", "Bide"],
+            population=[
+                ("Attack", "🗡️"), 
+                ("Block", "\N{SHIELD}"), 
+                ("Parry", "\N{CROSSED SWORDS}"), 
+                ("Heal", "\u2764"), 
+                ("Bide", "\u23F1")],
             weights=[50, 20, 20, 3, 7])[0]
         # Stores string information to display to player
         recent_turns = [
@@ -143,9 +148,14 @@ class PvE(commands.Cog):
                     f"You fled the battle as you ran out of time to move.")
 
             player.last_move = view.choice
-            boss.last_move = boss_next_move
+            boss.last_move = boss_next_move[0]
             boss_next_move = random.choices(
-                population=["Attack", "Block", "Parry", "Heal", "Bide"],
+                population=[
+                    ("Attack", "🗡️"), 
+                    ("Block", "\N{SHIELD}"), 
+                    ("Parry", "\N{CROSSED SWORDS}"), 
+                    ("Heal", "\u2764"), 
+                    ("Bide", "\u23F1")],
                 weights=[50, 20, 20, 3, 7])[0]
 
             # Calculate damage based off actions
@@ -154,10 +164,11 @@ class PvE(commands.Cog):
             if random.randint(1, 100) < 60: # ~65% chance of accurate prediction 
                 turn_msg += (
                     f"**{boss.name}** seems poised to "
-                    f"**{boss_next_move}**!")
+                    f"**{boss_next_move[1]}**!")
             else: # Throw the player off with a lie (might be true though)
                 deception = random.choice(
-                    ["Attack", "Block", "Parry", "Heal", "Bide"])
+                    ["🗡️", "\N{SHIELD}", "\N{CROSSED SWORDS}", 
+                     "\u2764", "\u23F1"])
                 turn_msg += f"**{boss.name}** seems poised to **{deception}**!"
             recent_turns.append(turn_msg)
             player, boss = combat_turn.apply_damage() # Apply to belligerents

--- a/cogs/PvE.py
+++ b/cogs/PvE.py
@@ -227,8 +227,8 @@ class PvE(commands.Cog):
                 gold += 200
             if player.accessory.prefix == "Lucky":
                 mult = Vars.ACCESSORY_BONUS["Lucky"][player.accessory.type]
-                xp = int(xp * (mult / 100.0))
-                gold = int(gold * (mult / 100.0))
+                xp = int(xp * (1 + (mult / 100.0)))
+                gold = int(gold * (1 + (mult / 100.0)))
             if player.accessory.prefix == "Old" and level >= 25 and victory:
                 gravitas = Vars.ACCESSORY_BONUS["Old"][player.accessory.type]
                 await author.give_gravitas(conn, gravitas)

--- a/cogs/PvE.py
+++ b/cogs/PvE.py
@@ -227,7 +227,7 @@ class PvE(commands.Cog):
                 gold += 200
             if player.accessory.prefix == "Lucky":
                 mult = Vars.ACCESSORY_BONUS["Lucky"][player.accessory.type]
-                xp = int(xp * (mult / 100.0))
+                xp = int(xp * (1 + (mult / 100.0)))
                 gold = int(gold * (mult / 100.0))
             if player.accessory.prefix == "Old" and level >= 25 and victory:
                 gravitas = Vars.ACCESSORY_BONUS["Old"][player.accessory.type]

--- a/cogs/PvE.py
+++ b/cogs/PvE.py
@@ -126,7 +126,7 @@ class PvE(commands.Cog):
                     f"Parry, \u2764 Heal, \u23F1 Bide"),
                 inline=False)
             embed.add_field(
-                name=f"Turn {turn_counter}", 
+                name=f"Turn {turn_counter} of 25", 
                 value="\n".join(recent_turns[-3:]),
                 inline=False)
 
@@ -227,7 +227,7 @@ class PvE(commands.Cog):
                 gold += 200
             if player.accessory.prefix == "Lucky":
                 mult = Vars.ACCESSORY_BONUS["Lucky"][player.accessory.type]
-                xp = int(xp * (1 + (mult / 100.0)))
+                xp = int(xp * (mult / 100.0))
                 gold = int(gold * (mult / 100.0))
             if player.accessory.prefix == "Old" and level >= 25 and victory:
                 gravitas = Vars.ACCESSORY_BONUS["Old"][player.accessory.type]

--- a/cogs/Travel.py
+++ b/cogs/Travel.py
@@ -128,8 +128,9 @@ class Travel(commands.Cog):
                 description=
                     "Type 'Yes' to cancel your current adventure if travelling",
                 required=False,
-                options=[OptionChoice("Yes"), OptionChoice("No")],
-                default="No")):
+                choices=[
+                    OptionChoice("CANCEL Adventure", "Yes"), 
+                    OptionChoice("CONTINUE Adventure", "No")])):
         """Complete your adventure/expedition and gain rewards!"""
         async with self.bot.db.acquire() as conn:
             player = await PlayerObject.get_player_by_id(conn, ctx.author.id)

--- a/cogs/Travel.py
+++ b/cogs/Travel.py
@@ -64,7 +64,9 @@ class Travel(commands.Cog):
                 description="The part of the map you are travelling to",
                 choices = [
                     OptionChoice(
-                        name=f"{t} ({Vars.TRAVEL_LOCATIONS[t]['Biome']})",
+                        name=(
+                            f"{t} ({Vars.TRAVEL_LOCATIONS[t]['Biome']}: "
+                            f"{Vars.TRAVEL_LOCATIONS[t]['Forage']})"),
                         value=t) 
                     for t in Vars.TRAVEL_LOCATIONS.keys()],
                 required=False

--- a/cogs/Travel.py
+++ b/cogs/Travel.py
@@ -161,8 +161,8 @@ class Travel(commands.Cog):
                     xp *= 3
                 if player.accessory.prefix == "Lucky":
                     mult = Vars.ACCESSORY_BONUS["Lucky"][player.accessory.type]
-                    xp = int(xp * (mult / 100.0))
-                    gold = int(gold * (mult / 100.0))
+                    xp = int(xp * (1 + (mult / 100.0)))
+                    gold = int(gold * (1 + (mult / 100.0)))
                 if rewards['weapon'] >= random.randint(1,100):
                     new_weapon = await ItemObject.create_weapon(
                         conn=conn,
@@ -240,8 +240,8 @@ class Travel(commands.Cog):
                 # Accessory bonus
                 if player.accessory.prefix == "Lucky":
                     mult = Vars.ACCESSORY_BONUS["Lucky"][player.accessory.type]
-                    xp = int(xp * (mult / 100.0))
-                    gold = int(gold * (mult / 100.0))
+                    xp = int(xp * (1 + (mult / 100.0)))
+                    gold = int(gold * (1 + (mult / 100.0)))
 
                 # Create the embed to send
                 embed = discord.Embed(title="Expedition Complete!", 

--- a/cogs/Travel.py
+++ b/cogs/Travel.py
@@ -483,7 +483,7 @@ class Travel(commands.Cog):
                 min_value=1,
                 max_value=15,
                 default=1)):
-        """Upgrade a weapon's ATK stat. Costs 8*ATK iron and 35*ATK gold."""
+        """Upgrade a weapon's ATK stat. Costs 8\*ATK iron and 35\*ATK gold."""
         async with self.bot.db.acquire() as conn:
             player = await PlayerObject.get_player_by_id(conn, ctx.author.id)
             if player.location not in ("Aramithea", "Riverburn", "Thenuille"):

--- a/cogs/Travel.py
+++ b/cogs/Travel.py
@@ -130,7 +130,8 @@ class Travel(commands.Cog):
                 required=False,
                 choices=[
                     OptionChoice("CANCEL Adventure", "Yes"), 
-                    OptionChoice("CONTINUE Adventure", "No")])):
+                    OptionChoice("CONTINUE Adventure", "No")],
+                default="No")):
         """Complete your adventure/expedition and gain rewards!"""
         async with self.bot.db.acquire() as conn:
             player = await PlayerObject.get_player_by_id(conn, ctx.author.id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py-cord @ git+https://github.com/Pycord-Development/pycord@d9807cd516ba248bfd03c5d57ca8c5c6e902a460
+py-cord==2.0.0b1
 asyncpg==0.25.0
 aiohttp==3.7.4.post0
 coolname==1.1.0


### PR DESCRIPTION
Display turn limit in PvE
Accessories with "Lucky" prefix now give correct rewards
Make `/arrive:cancel` more intuitive
Travel Menu shows the resources you can get from foraging in that area
Uses emojis instead of the action word in combat
If a player gains enough xp to level up multiple times, they will get the rewards for all level ups
If a player has multiple command instances and gains xp from each of them, they will no longer get the reward for levelling up to the same level multiple times.
`/lore` cooldown is now 1 use per day
	Players at or below level 10 don't have this cooldown
	Not choosing a new occupation/origin will not activate this cooldown
Add `/exchange` to trade in excess resources for others