### PR TITLE
2.2.2 Errors and Fixes

### DIFF
--- a/Utilities/AyeshaBot.py
+++ b/Utilities/AyeshaBot.py
@@ -16,6 +16,7 @@ class Ayesha(commands.AutoShardedBot):
         self.daily_claimers = {}
         self.recent_voters = {}
         self.trading_players = {}
+        self.training_players = {}
 
         super().__init__(command_prefix = "%", case_insensitive = True)
 
@@ -44,10 +45,19 @@ class Ayesha(commands.AutoShardedBot):
 
         print("Ayesha is online.")
 
-    async def on_interaction(self, interaction):
+    async def on_interaction(self, interaction : discord.Interaction):
         if interaction.user.id in self.trading_players:
             return await interaction.response.send_message(
                 f"Finish your trade first.")
+
+        if interaction.user.id in self.training_players:
+            if self.training_players[interaction.user.id] != interaction.custom_id:
+                # NOTE: This entire operation exists solely to prevent this
+                #   message from being printed after the training goes through
+                #   i.e. this still printed when the player responded to the 
+                #   original command. The things I have to do...
+                return await interaction.response.send_message(
+                    f"Finish your training first.")
 
         return await super().on_interaction(interaction)
 

--- a/Utilities/AyeshaBot.py
+++ b/Utilities/AyeshaBot.py
@@ -57,7 +57,7 @@ class Ayesha(commands.AutoShardedBot):
                 #   i.e. this still printed when the player responded to the 
                 #   original command. The things I have to do...
                 return await interaction.response.send_message(
-                    f"Finish your training first.")
+                    f"Finish your operation first.")
 
         return await super().on_interaction(interaction)
 

--- a/Utilities/ConfirmationMenu.py
+++ b/Utilities/ConfirmationMenu.py
@@ -26,6 +26,25 @@ class ConfirmationMenu(PlayerOnlyView):
         self.value = False
         self.stop()
 
+class LockedConfirmationMenu(PlayerOnlyView):
+    def __init__(self, user : discord.Member, custom_id : str, *args, **kwargs):
+        super().__init__(user=user, *args, **kwargs)
+        self.custom_id = custom_id
+        self.value = None
+
+    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.green, row=4)
+    async def confirm(self, button : discord.ui.Button, 
+            interaction : discord.Interaction):
+        self.value = True
+        interaction.custom_id = self.custom_id
+        self.stop()
+
+    @discord.ui.button(label="Decline", style=discord.ButtonStyle.red, row=4)
+    async def decline(self, button : discord.ui.Button, 
+            interaction : discord.Interaction):
+        self.value = False
+        interaction.custom_id = self.custom_id
+        self.stop()
 
 class OneButtonView(discord.ui.View):
     """Creates a view with one button to press"""

--- a/ayesha.py
+++ b/ayesha.py
@@ -6,6 +6,7 @@ import sys
 from Utilities import config, Vars
 from Utilities.AyeshaBot import Ayesha
 
+# Create base logger
 logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
 handler = logging.FileHandler(filename=config.LOG_FILE, 
@@ -14,6 +15,10 @@ handler = logging.FileHandler(filename=config.LOG_FILE,
 handler.setFormatter(logging.Formatter(
     '%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
 logger.addHandler(handler)
+
+# Wipe error logger
+with open(config.ERROR_LOG_FILE, "w") as f:
+    pass
 
 # Load Cogs
 init_cogs = [
@@ -44,7 +49,7 @@ if "-b" in sys.argv: # Run beta version
 bot = Ayesha(init_cogs)
 bot.run(config.TOKEN)
 
-# Ping command
+# Ping command; currently not in use
 @bot.slash_command(guild_ids=[762118688567984151])
 async def ping(ctx):
     """Ping to see if bot is working."""

--- a/cogs/Casino.py
+++ b/cogs/Casino.py
@@ -130,7 +130,8 @@ class Casino(commands.Cog):
             # Game is printed as an embed            
             display = discord.Embed(
                 title=f"Craps: {ctx.author.display_name}", color=Vars.ABLUE)
-            display.set_footer(text=ctx.author, icon_url=ctx.author.avatar.url)
+            display.set_footer(text=ctx.author, 
+                icon_url=ctx.author.display_avatar.url)
             display.add_field(
                 name=f"Press Shoot! to roll the die!", 
                 value=(f"Numbers to win: 7, 11\nNumbers to lose: 2, 3, 12"))

--- a/cogs/Casino.py
+++ b/cogs/Casino.py
@@ -42,15 +42,15 @@ class Casino(commands.Cog):
             if player.gold < wager:
                 raise Checks.NotEnoughGold(wager, player.gold)
 
-            msg = f"The coin landed on **{call}**!"
+            msg = lambda x : f"The coin landed on **{x}**!"
             if random.choice(["Heads", "Tails"]) == call:
                 await player.give_gold(conn, wager)
-                await ctx.respond(f"{msg} You made `{wager}` gold.")
+                await ctx.respond(f"{msg(call)} You made `{wager}` gold.")
             else:
                 await player.give_gold(conn, -wager)
                 call = "Tails" if call == "Heads" else "Heads"
                 await ctx.respond(
-                    f"{msg} You lost your `{wager}` gold wager.")
+                    f"{msg(call)} You lost your `{wager}` gold wager.")
 
     @commands.slash_command()
     @commands.check(Checks.is_player)

--- a/cogs/Error_Handler.py
+++ b/cogs/Error_Handler.py
@@ -118,8 +118,7 @@ class Error_Handler(commands.Cog):
             await ctx.respond(message)
             print_traceback = False
 
-        if isinstance(
-                error, Checks.PlayerNotInSpecifiedAssociation):
+        if isinstance(error, Checks.PlayerNotInSpecifiedAssociation):
             message = (
                 f"This player is not in your {error.type}.")
             await ctx.respond(message)

--- a/cogs/Error_Handler.py
+++ b/cogs/Error_Handler.py
@@ -99,6 +99,35 @@ class Error_Handler(commands.Cog):
             await ctx.respond(message)
             print_traceback = False
 
+        if isinstance(error, Checks.InAssociation):
+            message = "You are already in an association!"
+            await ctx.respond(message)
+            print_traceback = False
+
+        if isinstance(error, Checks.IncorrectAssociationRank):
+            message = (
+                f"You need to be an Association {error.rank} "
+                f"to use this command.")
+            await ctx.respond(message)
+            print_traceback = False
+
+        if isinstance(error, Checks.PlayerAlreadyChampion):
+            message = (
+                f"The player you have specified is already oen of your "
+                f"brotherhood's champions.")
+            await ctx.respond(message)
+            print_traceback = False
+
+        if isinstance(
+                error, Checks.PlayerNotInSpecifiedAssociation):
+            message = (
+                f"This player is not in your {error.type}.")
+            await ctx.respond(message)
+            print_traceback = False
+
+        if isinstance(error, commands.CommandNotFound):
+            print_traceback = False
+
         # --- CONCURRENCY ERROR ---
         if isinstance(error, commands.MaxConcurrencyReached):
             await ctx.respond(
@@ -203,52 +232,6 @@ class Error_Handler(commands.Cog):
             if isinstance(error.original, Checks.NotAcolyteOwner):
                 message = f"You do not own an acolyte with this ID."
                 await ctx.respond(message)
-                print_traceback = False
-
-            # --- ASSOCIATIONS ---
-            if isinstance(error.original, Checks.NotInAssociation):
-                # NOTE: this might be unnecessary
-                # pycord's error handling is just inconsistent
-                if error.original.req is None:
-                    message = (
-                        "You need to be in an association to use this "
-                        "command!\n Ask for an invitation to one or found your "
-                        "own with `/association create`!")
-                else:
-                    message = (
-                        f"You need to be in a {error.original.req} to use this "
-                        f"command!\nAsk for an invitation to one or found "
-                        f"your own with `/association create`!")
-                await ctx.respond(message)
-                print_traceback = False
-
-            if isinstance(error.original, Checks.InAssociation):
-                message = "You are already in an association!"
-                await ctx.respond(message)
-                print_traceback = False
-
-            if isinstance(error.original, Checks.IncorrectAssociationRank):
-                message = (
-                    f"You need to be an Association {error.original.rank} "
-                    f"to use this command.")
-                await ctx.respond(message)
-                print_traceback = False
-
-            if isinstance(error.original, Checks.PlayerAlreadyChampion):
-                message = (
-                    f"The player you have specified is already oen of your "
-                    f"brotherhood's champions.")
-                await ctx.respond(message)
-                print_traceback = False
-
-            if isinstance(
-                    error.original, Checks.PlayerNotInSpecifiedAssociation):
-                message = (
-                    f"This player is not in your {error.original.type}.")
-                await ctx.respond(message)
-                print_traceback = False
-
-            if isinstance(error.original, commands.CommandNotFound):
                 print_traceback = False
 
         # --- OFFICES ---

--- a/cogs/Error_Handler.py
+++ b/cogs/Error_Handler.py
@@ -38,7 +38,8 @@ class Error_Handler(commands.Cog):
                 error.__class__, error, error.__traceback__, file=sys.stderr)
 
     @commands.Cog.listener()
-    async def on_application_command_error(self, ctx, error):
+    async def on_application_command_error(self, 
+            ctx : discord.ApplicationContext, error):
         """The error handler for the bot.
         
         Apparently any errors raised during the actual command body will
@@ -273,8 +274,16 @@ class Error_Handler(commands.Cog):
             print_traceback = False
 
         if print_traceback:
+            error_context = (
+                f"----------------------------------\n"
+                f"COMMAND : {ctx.command.qualified_name}\n"
+                f"   USER : {ctx.author.id}\n"
+                f"  GUILD : {ctx.guild_id}\n"
+                f"OPTIONS : {ctx.selected_options}\n"
+                f"   OMIT : {ctx.unselected_options}\n"
+            )
             with open(ERROR_LOG_FILE, "a") as error_log:
-                print("----------------------------------", file=error_log)
+                print(error_context, file=error_log)
                 traceback.print_exception(
                     error.__class__, error, error.__traceback__, 
                     file=error_log)

--- a/cogs/Error_Handler.py
+++ b/cogs/Error_Handler.py
@@ -83,6 +83,21 @@ class Error_Handler(commands.Cog):
             await ctx.respond(message)
             print_traceback = False
 
+        # --- ASSOCIATIONS ---
+        if isinstance(error, Checks.NotInAssociation):
+            if error.req is None:
+                message = (
+                    "You need to be in an association to use this "
+                    "command!\n Ask for an invitation to one or found your "
+                    "own with `/association create`!")
+            else:
+                message = (
+                    f"You need to be in a {error.req} to use this "
+                    f"command!\nAsk for an invitation to one or found "
+                    f"your own with `/association create`!")
+            await ctx.respond(message)
+            print_traceback = False
+
         # --- CONCURRENCY ERROR ---
         if isinstance(error, commands.MaxConcurrencyReached):
             await ctx.respond(
@@ -191,6 +206,8 @@ class Error_Handler(commands.Cog):
 
             # --- ASSOCIATIONS ---
             if isinstance(error.original, Checks.NotInAssociation):
+                # NOTE: this might be unnecessary
+                # pycord's error handling is just inconsistent
                 if error.original.req is None:
                     message = (
                         "You need to be in an association to use this "

--- a/cogs/Error_Handler.py
+++ b/cogs/Error_Handler.py
@@ -52,7 +52,8 @@ class Error_Handler(commands.Cog):
         # --- CHARACTER RELATED ---
         if isinstance(error, Checks.HasChar):
             message = (f"You already have a character.\nFor help, read the "
-                       f"`/tutorial` or go to the `/support` server.")
+                       f"`/tutorial` or go to the support server (found in "
+                       f"the `/help` command).")
             await ctx.respond(message)
             print_traceback = False
 

--- a/cogs/Error_Handler.py
+++ b/cogs/Error_Handler.py
@@ -11,6 +11,7 @@ from discord.ui.item import Item
 
 from Utilities import Checks
 from Utilities.AyeshaBot import Ayesha
+from Utilities.config import ERROR_LOG_FILE
 
 class Error_Handler(commands.Cog):
     """Bot error handler."""
@@ -255,8 +256,12 @@ class Error_Handler(commands.Cog):
             print_traceback = False
 
         if print_traceback:
-            traceback.print_exception(
-                error.__class__, error, error.__traceback__, file=sys.stderr)
+            with open(ERROR_LOG_FILE, "a") as error_log:
+                print("----------------------------------", file=error_log)
+                traceback.print_exception(
+                    error.__class__, error, error.__traceback__, 
+                    file=error_log)
+                print("\n", file=error_log)
 
 def setup(bot):
     bot.add_cog(Error_Handler(bot))

--- a/cogs/Misc.py
+++ b/cogs/Misc.py
@@ -191,7 +191,7 @@ class Misc(commands.Cog):
             title=f"{ctx.author.display_name}'s Cooldowns",
             description="\n".join(cooldowns),
             color=Vars.ABLUE)
-        embed.set_thumbnail(url=ctx.author.avatar.url)
+        embed.set_thumbnail(url=ctx.author.display_avatar.url)
         embed.add_field(
             name="Adventure Status",
             value=adv_status)

--- a/cogs/Profile.py
+++ b/cogs/Profile.py
@@ -49,7 +49,10 @@ class Profile(commands.Cog):
                 title=f"Character Information: {profile.char_name}",
                 color=Vars.ABLUE
             )
-            page1.set_thumbnail(url=player.avatar.url)
+            try:
+                page1.set_thumbnail(url=player.avatar.url)
+            except AttributeError:
+                pass
             page1.add_field(name="Experience",
                 value=(
                     f"Level: `{level}`\n"
@@ -76,7 +79,10 @@ class Profile(commands.Cog):
                 title=f"Combat Loadout: {profile.char_name}",
                 color=Vars.ABLUE
             )
-            page2.set_thumbnail(url=player.avatar.url)
+            try:
+                page2.set_thumbnail(url=player.avatar.url)
+            except AttributeError:
+                pass
             page2.add_field(name="General",
                 value=(
                     f"Attack: `{profile.get_attack()}`\n"
@@ -125,7 +131,10 @@ class Profile(commands.Cog):
                 title=f"Backpack: {profile.char_name}",
                 color=Vars.ABLUE
             )
-            page3.set_thumbnail(url=player.avatar.url)
+            try:
+                page3.set_thumbnail(url=player.avatar.url)
+            except AttributeError:
+                pass
             for resource in Vars.MATERIALS:
                 page3.add_field(name=resource, value=pack[resource.lower()])
 

--- a/cogs/Profile.py
+++ b/cogs/Profile.py
@@ -49,10 +49,7 @@ class Profile(commands.Cog):
                 title=f"Character Information: {profile.char_name}",
                 color=Vars.ABLUE
             )
-            try:
-                page1.set_thumbnail(url=player.avatar.url)
-            except AttributeError:
-                pass
+            page1.set_thumbnail(url=player.display_avatar.url)
             page1.add_field(name="Experience",
                 value=(
                     f"Level: `{level}`\n"
@@ -79,10 +76,7 @@ class Profile(commands.Cog):
                 title=f"Combat Loadout: {profile.char_name}",
                 color=Vars.ABLUE
             )
-            try:
-                page2.set_thumbnail(url=player.avatar.url)
-            except AttributeError:
-                pass
+            page2.set_thumbnail(url=player.display_avatar.url)
             page2.add_field(name="General",
                 value=(
                     f"Attack: `{profile.get_attack()}`\n"
@@ -131,10 +125,7 @@ class Profile(commands.Cog):
                 title=f"Backpack: {profile.char_name}",
                 color=Vars.ABLUE
             )
-            try:
-                page3.set_thumbnail(url=player.avatar.url)
-            except AttributeError:
-                pass
+            page3.set_thumbnail(url=player.display_avatar.url)
             for resource in Vars.MATERIALS:
                 page3.add_field(name=resource, value=pack[resource.lower()])
 

--- a/cogs/Travel.py
+++ b/cogs/Travel.py
@@ -277,7 +277,7 @@ class Travel(commands.Cog):
                     "gold", gold, gold_bonus_sources)
                 embed = discord.Embed(title="Expedition Complete!", 
                     color=Vars.ABLUE)
-                embed.set_thumbnail(url=ctx.author.avatar.url)
+                embed.set_thumbnail(url=ctx.author.display_avatar.url)
                 e_message = (
                     f"While on your journey, you gained these resources:\n"
                     f"{gold_gains_str}\n{xp_gains_str}\n")

--- a/cogs/Vote.py
+++ b/cogs/Vote.py
@@ -37,6 +37,7 @@ class Vote_Handler:
 
     async def bot_list_stats(self):
         l = f"https://discordbotlist.com/api/v1/bots/{self.bot.user.id}/stats"
+        t = f"https://top.gg/api/bots/{self.bot.user.id}/stats"
         await self.bot.wait_until_ready()
         while not self.bot.is_closed():
             async with aiohttp.ClientSession() as client:
@@ -48,9 +49,12 @@ class Vote_Handler:
                         },
                         headers = {"Authorization" : config.DBL_TOKEN}
                         )
+                    await client.post(url=t,
+                        data = {"server_count" : len(self.bot.guilds)},
+                        headers = {"Authorization" : config.TOPGG_TOKEN})
                 # print(resp.status)
 
-            await asyncio.sleep(3600 * 24)
+            await asyncio.sleep(1800)
 
     async def get_handler(self, request):
         return web.Response(text='Idk what I\'m doing\n-Aramythia')
@@ -120,6 +124,6 @@ class Vote(commands.Cog):
         self.update_stats.cancel()
 
 def setup(client):
-    client.dbl = dbl.DBLClient(client, config.TOPGG_TOKEN, autopost=True)
+    # client.dbl = dbl.DBLClient(client, config.TOPGG_TOKEN, autopost=True)
 
     client.add_cog(Vote(client))


### PR DESCRIPTION
Prints errors to a file and fleshes out error context information
Fix a bug in which `/profile` would break due to the default avatar not being listed in `player.avatar`
Fix bug in which `/coinflip` gave incorrect messages when losing.
Fix bug in which server counts were not being posted to top.gg
Add the `ConfirmationMenu.LockedConfirmationMenu` class
Update `/train` and `/upgrade` to show exact resource expenditure and add a confirmation menu
Update command messages to reflect past changes in other modules